### PR TITLE
Explain how to use Gmail in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roundcube CVE-2021-44026, a SQL injection
 
-This repository contains a demo exploit for an [SQL injection in Roundcube](https://pentest-tools.com/blog/roundcube-cve-2021-44026).
+This repository contains a demo exploit for an [SQL injection in Roundcube](https://pentest-tools.com/blog/roundcube-exfiltrating-emails-with-cve-2021-44026).
 
 **Disclaimer**:
 
@@ -40,3 +40,5 @@ When ran, the code starts a Flask server, `c2_server` in the code, which does th
 
 1. It sends an email to a target from a given sender address. This email contains an exploit for another Roundcube vulnerability, an XSS tracked as [CVE-2020-35730](https://nvd.nist.gov/vuln/detail/CVE-2020-35730). We use it to send the requests necessary for the SQL injection from an authenticated session. All the JavaScript code that runs on the client side is in`static/fetcher.js`
 2. The JavaScript code extracts all the sessions from the database and sends them back to the C2 server as a _VCARD_. On the server side, the session variables are extracted from the _VCARD_. For each authenticated session the code extracts the most recent emails received.
+
+Note: You can use a Gmail account as the sender's email. Use `stmp.gmail.com` for the server and `587` for the port. Configure a password just for this usage by following the guide [here](https://support.google.com/mail/answer/185833?hl=en#zippy=).


### PR DESCRIPTION
Adds details about how to use Gmail as the SMTP server. Updates the URL to the blog article. 